### PR TITLE
Include webstorm version 222.*

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 1.0.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
Doesn't look like there are any breaking changes that would stop this plugin working but this will stop the popup telling me it's out of version.

I didn't include anything higher just in case any newer versions do break the plugin.